### PR TITLE
mem leak due to perf correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(rpn)
 
 if((NOT CMAKE_BUILD_TYPE MATCHES Debug)
     AND (NOT CMAKE_BUILD_TYPE MATCHES Release))
-    set(CMAKE_BUILD_TYPE Release CACHE string "Choose the type of build, options are: None Debug Release" FORCE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release" FORCE)
 endif()
 
 message(STATUS "Build mode: ${CMAKE_BUILD_TYPE}")

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -612,7 +612,10 @@ ret_value program::parse(string& entry) {
                     break;
                 default:
                     show_error(ret_unknown_err, "error creating program from entry");
+                    break;
             }
+            if (element.re != nullptr) delete element.re;
+            if (element.im != nullptr) delete element.im;
         }
     } else
         for (SynError& err : errors) show_syntax_error(err.err.c_str());

--- a/test/mem_test.sh
+++ b/test/mem_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rpn=../build/rpn
+rpn=../debug/rpn
 
 FG_RED="\033[0;31m"
 FG_GREEN="\033[0;32m"


### PR DESCRIPTION
- corrected a mem leak introduced by the #225 correction
- corrected the following CMake warning

```
CMake Warning (dev) at CMakeLists.txt:9 (set):
  implicitly converting 'string' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```