### PR TITLE
Harden branch checks on command flow indexes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,4 @@ TODO
 missing tests / problems
 - les arguments d'une fonction en erreur doivent ils être consommés ?
     ex embettant : sto+
-- `1 'i' sto while i <= 2 repeat 0 'j' sto while j <= 1 repeat i (1,0) * j (0,1) * + 1 'j' sto+ end 1 'i' sto+ end` plante
+- `1 'i' sto while i 2 <= repeat 0 'j' sto while 1 <= j repeat i (1,0) * j (0,1) * + 1 'j' sto+ end 1 'i' sto+ end` plante

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,7 +31,7 @@ class program;
 class branch;
 
 typedef void (program::*program_fn_t)(void);
-typedef int (program::*branch_fn_t)(branch&);
+typedef size_t (program::*branch_fn_t)(branch&);
 
 /// @brief object - a generic stack object
 ///
@@ -174,9 +174,9 @@ struct branch : object {
     branch() : object(cmd_branch) {}
     branch(branch_fn_t fn_, const string& value_) : object(cmd_branch) {
         fn = fn_;
-        arg1 = -1;
-        arg2 = -1;
-        arg3 = -1;
+        arg1 = (size_t)-1;
+        arg2 = (size_t)-1;
+        arg3 = (size_t)-1;
         arg_bool = 0;
         value = value_;
     }
@@ -191,7 +191,7 @@ struct branch : object {
     virtual object* clone() { return new branch(*this); }
     virtual string name() { return string("branch"); }
     branch_fn_t fn;
-    int arg1, arg2, arg3;
+    size_t arg1, arg2, arg3;
     mpreal firstIndex, lastIndex;
     bool arg_bool;
     string value;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -236,8 +236,8 @@ ret_value program::run() {
     }
 
     // iterate commands
-    for (int i = 0; (go_out == false) && (interrupt_now == false) && (i < (int)size());) {
-        object* o = (*this)[i];
+    for (size_t i = 0; (go_out == false) && (interrupt_now == false) && (i < size());) {
+        object* o = at(i);
         switch (o->_type) {
             // could be an auto-evaluated symbol
             case cmd_symbol:
@@ -281,18 +281,17 @@ ret_value program::run() {
             case cmd_branch: {
                 // call matching function
                 branch* b = (branch*)o;
-                int next_cmd = (this->*(b->fn))(*b);
+                size_t next_cmd = (this->*(b->fn))(*b);
                 switch (next_cmd) {
-                    case -1:
+                    case step_out: // step out
                         i++;  // meaning 'next command'
                         break;
-                    case -(int)ret_runtime_error:
-                        // error: show it
+                    case runtime_error: // runtime error
                         (void)show_error(_err, _err_context);
-                        go_out = true;  // end of run
+                        go_out = true;
                         break;
                     default:
-                        i = next_cmd;  // new direction
+                        i = next_cmd;
                         break;
                 }
                 break;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -13,9 +13,9 @@ using namespace mpfr;
 
 // internal includes
 #include "constant.h"
+#include "lexer.hpp"
 #include "object.hpp"
 #include "stack.hpp"
-#include "lexer.hpp"
 
 //< convinient structure to preprocess a program
 struct if_layout_t {
@@ -32,7 +32,7 @@ struct if_layout_t {
 //< program class: the class containing a string parser, all the programs keywords, a stack for running the program
 class program : public deque<object*>, public Lexer {
    public:
-    program(rpnstack& stk, heap& hp, program* parent = nullptr):_stack(stk),_heap(hp),_parent(parent) {
+    program(rpnstack& stk, heap& hp, program* parent = nullptr) : _stack(stk), _heap(hp), _parent(parent) {
         interrupt_now = false;
     }
     virtual ~program() {
@@ -99,20 +99,21 @@ class program : public deque<object*>, public Lexer {
     ////
 
     // branch
-    int rpn_if(branch& myobj);
-    int rpn_then(branch& myobj);
-    int rpn_else(branch& myobj);
-    int rpn_end(branch& myobj);
-    int rpn_do(branch& myobj);
-    int rpn_until(branch& myobj);
+    size_t rpn_if(branch& myobj);
+    size_t rpn_then(branch& myobj);
+    size_t rpn_else(branch& myobj);
+    size_t rpn_end(branch& myobj);
+    size_t rpn_do(branch& myobj);
+    size_t rpn_until(branch& myobj);
     void rpn_ift(void);
     void rpn_ifte(void);
-    int rpn_while(branch& myobj);
-    int rpn_repeat(branch& myobj);
-    int rpn_start(branch& myobj);
-    int rpn_for(branch& myobj);
-    int rpn_next(branch& myobj);
-    int rpn_step(branch& myobj);
+    size_t rpn_while(branch& myobj);
+    size_t rpn_repeat(branch& myobj);
+    size_t rpn_start(branch& myobj);
+    size_t rpn_for(branch& myobj);
+    size_t rpn_next(branch& myobj);
+    size_t rpn_step(branch& myobj);
+    enum { step_out = (size_t)-1, runtime_error = (size_t)-2 };
 
     // complex
     void rpn_re();

--- a/src/rpn-test.cpp
+++ b/src/rpn-test.cpp
@@ -17,7 +17,6 @@ long program::cmp_strings_on_stack_top() {
 ///
 void program::rpn_sup(void) {
     MIN_ARGUMENTS(2);
-
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) > _stack.value<number>(0)));
@@ -35,7 +34,6 @@ void program::rpn_sup(void) {
 ///
 void program::rpn_sup_eq(void) {
     MIN_ARGUMENTS(2);
-
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) >= _stack.value<number>(0)));
@@ -53,7 +51,6 @@ void program::rpn_sup_eq(void) {
 ///
 void program::rpn_inf(void) {
     MIN_ARGUMENTS(2);
-
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) < _stack.value<number>(0)));
@@ -70,6 +67,7 @@ void program::rpn_inf(void) {
 /// @brief <= keyword implementation
 ///
 void program::rpn_inf_eq(void) {
+    MIN_ARGUMENTS(2);
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) <= _stack.value<number>(0)));
@@ -87,7 +85,6 @@ void program::rpn_inf_eq(void) {
 ///
 void program::rpn_diff(void) {
     MIN_ARGUMENTS(2);
-
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) != _stack.value<number>(0)));
@@ -110,7 +107,6 @@ void program::rpn_diff(void) {
 ///
 void program::rpn_eq(void) {
     MIN_ARGUMENTS(2);
-
     // numbers
     if (_stack.type(0) == cmd_number && _stack.type(1) == cmd_number) {
         _stack.push_front(new number(_stack.value<number>(1) == _stack.value<number>(0)));


### PR DESCRIPTION
- hardening branch functions: now returning size_t as next obj index instead of int
- adding checks on indexes in branch functions
- correcting a missing check in rpn_inf_eq
