### PR TITLE
Resync develop

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   pull_request:
-    branches: [ v2.4.0-devel, master ]
+    branches: [ develop, master ]
 
 env:
   BUILD_TYPE: Release

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,7 +18,7 @@ static void ExitInteractive() {
     struct passwd* pw = getpwuid(getuid());
     if (pw != nullptr) {
         stringstream history_path;
-        history_path << pw->pw_dir << "/.RpnHistory";
+        history_path << pw->pw_dir << "/.rpn_history";
 
         // trunc current history
         ofstream history(history_path.str(), ios_base::out | ios_base::trunc);
@@ -38,7 +38,7 @@ static void EnterInteractive() {
     struct passwd* pw = getpwuid(getuid());
     if (pw != nullptr) {
         stringstream history_path;
-        history_path << pw->pw_dir << "/.RpnHistory";
+        history_path << pw->pw_dir << "/.rpn_history";
 
         // don't care about errors
         linenoiseHistorySetMaxLen(100);


### PR DESCRIPTION
Resynchronize develop and master, following #257.
Including
- changing back the history file from .RpnHistory to .rpn_history.
- github action flow now acts on develop branch
